### PR TITLE
Fix command line parsing bug

### DIFF
--- a/src/main/scala/CommandLine.scala
+++ b/src/main/scala/CommandLine.scala
@@ -13,8 +13,8 @@ object Driver {
       case Seq(switch, xs @ _*) 
         if (switch startsWith "--") && (switch contains "=")
         =>
-        val name = switch drop 2 takeWhile("=" !=)
-        val value = switch dropWhile("=" !=) tail
+        val name = switch drop 2 takeWhile('=' !=)
+        val value = switch dropWhile('=' !=) tail
         val (switches, args) = parseOpts(xs)
         (switches + (name -> value), args)
       case Seq(switch, value, xs @ _*) if switch startsWith "--" =>


### PR DESCRIPTION
Fixes command line parsing bug when accidentally searching for strings instead of chars.

I paste the ST here for friends looking up a solution through Google:

```
run-main me.winslow.d.mn2gt.Driver /home/appserv/osm_files/osm.xml --rest=http://localhost:8080/geoserver/rest --user=admin --password=geoserver --data-dir=/opt/geoserver/geoserver/data_dir --prefix=argentina --namespace=http://cartografia.dearin.afip.gob.ar/argentina"
[info] Loading project definition from /home/appserv/downloads/mapnik2geotools/project
[info] Set current project to mn2gt (in build file:/home/appserv/downloads/mapnik2geotools/)
[error] java.lang.UnsupportedOperationException: empty.tail
[error]     at scala.collection.TraversableLike$class.tail(TraversableLike.scala:395)
[error]     at scala.collection.immutable.StringOps.scala$collection$IndexedSeqOptimized$$super$tail(StringOps.scala:31)
[error]     at scala.collection.IndexedSeqOptimized$class.tail(IndexedSeqOptimized.scala:124)
[error]     at scala.collection.immutable.StringOps.tail(StringOps.scala:31)
[error]     at me.winslow.d.mn2gt.Driver$.parseOpts(CommandLine.scala:17)
[error]     at me.winslow.d.mn2gt.Driver$.parseOpts(CommandLine.scala:26)
[error]     at me.winslow.d.mn2gt.Driver$.main(CommandLine.scala:58)
[error]     at me.winslow.d.mn2gt.Driver.main(CommandLine.scala)
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
[error]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:606)
[error]     at scala.tools.nsc.util.ScalaClassLoader$$anonfun$run$1.apply(ScalaClassLoader.scala:78)
[error]     at scala.tools.nsc.util.ScalaClassLoader$class.asContext(ScalaClassLoader.scala:24)
[error]     at scala.tools.nsc.util.ScalaClassLoader$URLClassLoader.asContext(ScalaClassLoader.scala:88)
[error]     at scala.tools.nsc.util.ScalaClassLoader$class.run(ScalaClassLoader.scala:78)
[error]     at scala.tools.nsc.util.ScalaClassLoader$URLClassLoader.run(ScalaClassLoader.scala:101)
[error]     at scala.tools.nsc.ObjectRunner$.run(ObjectRunner.scala:33)
[error]     at scala.tools.nsc.ObjectRunner$.runAndCatch(ObjectRunner.scala:40)
[error]     at scala.tools.nsc.MainGenericRunner.runTarget$1(MainGenericRunner.scala:56)
[error]     at scala.tools.nsc.MainGenericRunner.process(MainGenericRunner.scala:80)
[error]     at scala.tools.nsc.MainGenericRunner$.main(MainGenericRunner.scala:89)
[error]     at scala.tools.nsc.MainGenericRunner.main(MainGenericRunner.scala)
java.lang.RuntimeException: Nonzero exit code returned from runner: 1
    at scala.sys.package$.error(package.scala:27)
...
```
